### PR TITLE
WebPurifyImage#imgStatus: require exactly one of imgid or customimgid

### DIFF
--- a/src/WebPurify/WebPurify.php
+++ b/src/WebPurify/WebPurify.php
@@ -231,6 +231,35 @@ abstract class WebPurify implements LoggerAwareInterface
     }
 
     /**
+     * Check exactly one of the given parameters exists
+     *
+     * Static method for checking that exactly one of the given parameters
+     * exists in the $params array passed to WebPurity methods
+     *
+     * @param array $userInput A hash of HTTP GET/POST parameters
+     * @param array $required  An array of parameters
+     */
+    protected static function requireExactlyOneParamFrom($userInput, $parameters)
+    {
+        $count = 0;
+        foreach ($parameters as $requiredParam) {
+            if (isset($userInput[$requiredParam])) {
+                if (++$count > 1) {
+                    break;
+                }
+            }
+        }
+
+        if ($count !== 1) {
+            throw new WebPurifyException(
+                'Exactly one of the parameters '
+                . implode(', ', $parameters)
+                . ' required for API request'
+            );
+        }
+    }
+
+    /**
      * Send to log
      *
      * Pass information through to monolog

--- a/src/WebPurify/WebPurifyImage.php
+++ b/src/WebPurify/WebPurifyImage.php
@@ -56,7 +56,7 @@ class WebPurifyImage extends WebPurify
             $params = array('imgid' => $params);
         }
 
-        WebPurify::requireParams($params, array('imgid'));
+        WebPurify::requireExactlyOneParamFrom($params, array('imgid', 'customimgid'));
 
         $response = $this->request('imgstatus', $params, static::END_POINT_DOMAIN_IMAGES);
 


### PR DESCRIPTION
Though it is undocumented, Webpurify's API can alternatively find and
return the status of an image by customimgid rather than imgid. This
patch allows us to query imgstatus in this way.

From Webpurify support:

> As for looking up the status using the custom id, this feature is in
> BETA, however you are more than welcome to use it. We plan on
> bringing it out of beta, which simply means posting the
> documentation on our website by the New Year.